### PR TITLE
feat: setup files validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+updates:
+- package-ecosystem: gomod
+  directories:
+    - "/"
+    - "/tools"
+  schedule:
+    interval: weekly
+  rebase-strategy: disabled
+  commit-message:
+      prefix: ":seedling:"
+  groups:
+    gomod:
+      patterns:
+        - "*"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+      interval: "weekly"
+  rebase-strategy: disabled
+  commit-message:
+      prefix: ":seedling:"
+  groups:
+    github-actions:
+      patterns:
+        - "*"
+      # These actions directly influence the build process and are excluded from grouped updates
+      exclude-patterns:
+        - "actions/setup-go"
+        - "goreleaser/goreleaser-action"

--- a/.github/workflows/ci-ariwete.yaml
+++ b/.github/workflows/ci-ariwete.yaml
@@ -16,12 +16,12 @@ name: CI
 on:
   push:
     paths:
-      - 'ariwete/**'
+      - ariwete/**
     branches:
       - main
   pull_request:
     paths:
-      - 'ariwete/**'
+      - ariwete/**
 
 env:
   GO_VERSION: ^1.22.0
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 5
     defaults:
       run:
-        working-directory: 'ariwete/'
+        working-directory: ariwete/
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -50,11 +50,11 @@ jobs:
     timeout-minutes: 5
     defaults:
       run:
-        working-directory: 'ariwete/'
+        working-directory: ariwete/
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Run tests
-        run: go test ./...
+        run: go test -v ./...

--- a/ariwete/README.md
+++ b/ariwete/README.md
@@ -25,6 +25,20 @@ For example:
   // The package file where the tests should be run (required).
   "package-file": "package.json",
 
+  // CI setup file, must be located in the same directory as the package file.
+  "ci-setup-filename": "ci-setup.json",
+
+  // CI setup defaults, used when no setup file or field is not sepcified in file.
+  "ci-setup-defaults": {
+    "node-version": 20,
+    "timeout-minutes": 10,
+    "env": {}, // Key value pairs of environment variables.
+    "secrets": {} // Secret Manager secrets to export as environment variables.
+  },
+
+  // CI setup help URL, shown when a setup file validation fails.
+  "ci-setup-help-url": "https://example.com/path/to/config-setup-docs.html",
+
   // Match diffs only on .js and .ts files
   // Defaults to match all files.
   "match": ["*.js", "*.ts"],

--- a/ariwete/README.md
+++ b/ariwete/README.md
@@ -2,9 +2,10 @@
 
 TODO: describe the tool and inspiration from community oriented endurance running.
 
-This tool has one function:
+This tool has two functions:
 
 - `affected` finds the affected packages given a list of diffs.
+- `setup-files` loads and validates the setup files settings for each package.
 
 ## Config files
 
@@ -40,22 +41,22 @@ For example:
 
 For more information, see [`pkg/utils/config.go`](pkg/utils/config.go).
 
-## Building
-
-To build the tools, we must change to the directory where the tools package is defined.
-We can run it in a subshell using parentheses to keep our working directory from changing.
-
-```sh
-(cd ariwete && go build -o /tmp/tools ./cmd/...)
-```
-
-## Running the tools unit tests
+## Running the unit tests
 
 To the tools tests, we must change to the directory where the tools package is defined.
 We can run it in a subshell using parentheses to keep our working directory from changing.
 
 ```sh
 (cd ariwete && go test -v ./...)
+```
+
+## Building
+
+To build the tools, we must change to the directory where the tools package is defined.
+We can run it in a subshell using parentheses to keep our working directory from changing.
+
+```sh
+(cd ariwete && go build -o /tmp/ariwete ./cmd/...)
 ```
 
 ## Finding affected packages
@@ -72,9 +73,32 @@ You can also create the file manually if you want to test something without comm
 git --no-pager diff --name-only HEAD origin/main | tee /tmp/diffs.txt
 ```
 
-Now we can check which packages have been affected.
-We pass the config file and the diffs file as positional arguments.
+Then run the `affected` command, with the following positional arguments:
+
+1. The `config.jsonc` file path.
+1. The `diffs.txt` file path.
+1. The `paths.txt` file path to write the affected packages to.
 
 ```sh
-/tmp/tools affected .github/config/nodejs.jsonc /tmp/diffs.txt
+/tmp/ariwete affected \
+    path/to/config.jsonc \
+    /tmp/diffs.txt \
+    /tmp/paths.txt
+```
+
+The output paths file contains one path per line.
+
+## Loading the setup files
+
+> This must run at the repository root directory.
+
+Then run the `setup-files` command, with the following positional arguments:
+
+1. The `config.jsonc` file path.
+1. The `paths.txt` file with the packages of interest.
+
+```sh
+/tmp/ariwete setup-files \
+    path/to/config.jsonc \
+    /tmp/paths.txt
 ```

--- a/ariwete/README.md
+++ b/ariwete/README.md
@@ -34,7 +34,7 @@ For example:
 
   // Skip these packages, these could be handled by a different config.
   // Defaults to not exclude anything.
-  "exclude-packages": ["path/to/slow-to-test", "special-config-package"],
+  "exclude-packages": ["path/to/slow-to-test", "special-config-package"]
 }
 ```
 
@@ -46,7 +46,7 @@ To build the tools, we must change to the directory where the tools package is d
 We can run it in a subshell using parentheses to keep our working directory from changing.
 
 ```sh
-(go build -o /tmp/tools ./cmd/*)
+(cd ariwete && go build -o /tmp/tools ./cmd/...)
 ```
 
 ## Running the tools unit tests
@@ -55,7 +55,7 @@ To the tools tests, we must change to the directory where the tools package is d
 We can run it in a subshell using parentheses to keep our working directory from changing.
 
 ```sh
-(go test ./...)
+(cd ariwete && go test -v ./...)
 ```
 
 ## Finding affected packages

--- a/ariwete/cmd/ariwete/main.go
+++ b/ariwete/cmd/ariwete/main.go
@@ -133,9 +133,9 @@ func setupFilesCmd(configFile string, pathsFile string) {
 	// Trim whitespace to remove extra newline from diff output.
 	paths := strings.Split(strings.TrimSpace(string(pathsBytes)), "\n")
 
-	setups, err := config.FindSetupFiles(paths)
-	if err != nil {
-		log.Fatalln("❌ error finding setup files.\n", err)
+	setups, errors := config.FindSetupFiles(paths)
+	if len(errors) > 0 {
+		log.Fatalf("❌ could not load setup files.\n%v\n%v\n", err, strings.Join(errors, "\n"))
 	}
 
 	output, err := json.Marshal(setups)

--- a/ariwete/cmd/ariwete/main.go
+++ b/ariwete/cmd/ariwete/main.go
@@ -135,7 +135,18 @@ func setupFilesCmd(configFile string, pathsFile string) {
 
 	setups, errors := config.FindSetupFiles(paths)
 	if len(errors) > 0 {
-		log.Fatalf("❌ could not load setup files.\n%v\n%v\n", err, strings.Join(errors, "\n"))
+		var sb strings.Builder
+		sb.WriteString("❌ could not load setup files.\n")
+		sb.WriteString(err.Error() + "\n")
+		for _, e := range errors {
+			sb.WriteString(e + "\n")
+		}
+		if config.CISetupHelpURL != "" {
+			sb.WriteString("\n")
+			sb.WriteString("For more information, see:\n")
+			sb.WriteString(fmt.Sprintf("  %v\n", config.CISetupHelpURL))
+		}
+		log.Fatalln(sb.String())
 	}
 
 	output, err := json.Marshal(setups)

--- a/ariwete/pkg/config/config.go
+++ b/ariwete/pkg/config/config.go
@@ -255,11 +255,5 @@ func (c *Config) ValidateCISetup(setup CISetup) []string {
 			}
 		}
 	}
-	// // Help URL.
-	// if c.CISetupHelpURL != "" {
-	// 	sb.WriteString("\n")
-	// 	sb.WriteString("For more information, see:\n")
-	// 	sb.WriteString(fmt.Sprintf("  %v\n", c.CISetupHelpURL))
-	// }
 	return errors
 }


### PR DESCRIPTION
This adds validation to `ci-setup.json` files. The following checks are done:

* Returns all validation errors for all setup files
* Check that fields are defined by the defaults
* Check the type of the fields
* Allows "comment fields" if it starts with an underscore
* Clear and actionable error messages
* Optionally define a URL to redirect for more information