### PR TITLE
chore: configure release-please

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,0 +1,7 @@
+{
+    "packages": {
+        "cmd/custard": {
+            "release-type": "go"
+        }
+    }
+}

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+handleGHRelease: true
+manifest: true
+manifestConfig: ./github/release-please-config.json

--- a/custard/cmd/custard/main.go
+++ b/custard/cmd/custard/main.go
@@ -26,11 +26,14 @@ import (
 	"strings"
 )
 
+const Version = "0.2.3" // x-release-please-version
+
 var usage = `usage: custard <command> ...
 
 commands:
   affected path/to/config.jsonc diffs.txt paths.txt
   setup-files path/to/config.jsonc paths.txt
+  version
 `
 
 // Entry point to validate command line arguments.
@@ -68,6 +71,9 @@ func main() {
 			log.Fatalln("❌ no paths file specified\n", usage)
 		}
 		setupFilesCmd(configFile, pathsFile)
+
+	case "version":
+		log.Println("custard version:", Version)
 
 	default:
 		log.Fatalln("❌ unknown command: ", command, "\n", usage)


### PR DESCRIPTION
Configures release-please to handle releases b/407623122

Manually adds `Version`, but this could be derived from `build.Main.version` if we update to use go 1.24. 