### PR TITLE
fix: fix syntax error on get-job

### DIFF
--- a/actions/steps/get-job/action.yaml
+++ b/actions/steps/get-job/action.yaml
@@ -53,7 +53,7 @@ runs:
                 owner: owner,
                 repo: repo,
                 run_id: run_id,
-                page: page;
+                page: page,
               });
               if (response.data.jobs.length === 0) {
                 break;


### PR DESCRIPTION
This syntax error was introduced before we tested all our workflows both on pull_request and workflow_run, including adding checks for both of them.