### PR TITLE
fix: update steps as part of release-please config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -10,8 +10,8 @@
         "extra-files": [
           "README.md",
           "custard/cmd/custard/main.go",
-          {"type": "yaml", "jsonpath": "$.runs.steps.*.uses",   "path": "actions/steps/create-check/action.yaml" },
-          {"type": "yaml", "jsonpath": "$.runs.steps.*.uses",   "path": "actions/steps/update-check/action.yaml" }
+          {"type": "yaml", "jsonpath": "$.runs.steps.*.uses", "path": "actions/steps/create-check/action.yaml" },
+          {"type": "yaml", "jsonpath": "$.runs.steps.*.uses", "path": "actions/steps/update-check/action.yaml" }
         ]
       }
     },

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,19 +1,27 @@
 {
-    "packages": {
-      ".": {
-        "changelog-path": "CHANGELOG.md",
-        "release-type": "go",
-        "bump-minor-pre-major": false,
-        "bump-patch-for-minor-pre-major": false,
-        "draft": false,
-        "prerelease": false,
-        "extra-files": [
-          "README.md",
-          "custard/cmd/custard/main.go",
-          {"type": "yaml", "jsonpath": "$.runs.steps.*.uses", "path": "actions/steps/create-check/action.yaml" },
-          {"type": "yaml", "jsonpath": "$.runs.steps.*.uses", "path": "actions/steps/update-check/action.yaml" }
-        ]
-      }
-    },
-    "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
-  }
+  "packages": {
+    ".": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "go",
+      "bump-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": false,
+      "draft": false,
+      "prerelease": false,
+      "extra-files": [
+        "README.md",
+        "custard/cmd/custard/main.go",
+        {
+          "type": "yaml",
+          "jsonpath": "$.runs.steps.*.uses",
+          "path": "actions/steps/create-check/action.yaml"
+        },
+        {
+          "type": "yaml",
+          "jsonpath": "$.runs.steps.*.uses",
+          "path": "actions/steps/update-check/action.yaml"
+        }
+      ]
+    }
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
+}

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -9,7 +9,9 @@
         "prerelease": false,
         "extra-files": [
           "README.md",
-          "custard/cmd/custard/main.go"
+          "custard/cmd/custard/main.go",
+          {"type": "yaml", "jsonpath": "$.runs.steps.*.uses",   "path": "actions/steps/create-check/action.yaml" },
+          {"type": "yaml", "jsonpath": "$.runs.steps.*.uses",   "path": "actions/steps/update-check/action.yaml" }
         ]
       }
     },


### PR DESCRIPTION
#57 

In theory, we can update files outside of .github/workflows with release-please. 

The current errors in #56 are due to the version being tested being the version from the release, when the release versions should be updated at the same time

(That is, actions/steps are part of the release, .github/workflows updates are the implementation of that release)