### PR TITLE
fix: use generic updater for yaml files, prevent header check issues

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -10,16 +10,8 @@
       "extra-files": [
         "README.md",
         "custard/cmd/custard/main.go",
-        {
-          "type": "yaml",
-          "jsonpath": "$.runs.steps.*.uses",
-          "path": "actions/steps/create-check/action.yaml"
-        },
-        {
-          "type": "yaml",
-          "jsonpath": "$.runs.steps.*.uses",
-          "path": "actions/steps/update-check/action.yaml"
-        }
+        "actions/steps/create-check/action.yaml",
+        "actions/steps/update-check/action.yaml"
       ]
     }
   },

--- a/actions/steps/create-check/action.yaml
+++ b/actions/steps/create-check/action.yaml
@@ -45,6 +45,7 @@ outputs:
     description: The whole check in JSON.
     value: ${{ steps.check.outputs.check }}
 
+# x-release-please-start-version
 runs:
   using: composite
   steps:
@@ -66,3 +67,4 @@ runs:
         repository-name: ${{ inputs.repository-name }}
         repository-owner: ${{ inputs.repository-owner }}
         if: ${{ inputs.if }}
+# x-release-please-end-version

--- a/actions/steps/update-check/action.yaml
+++ b/actions/steps/update-check/action.yaml
@@ -33,6 +33,7 @@ outputs:
     description: The whole check in JSON.
     value: ${{ steps.check.outputs.check }}
 
+# x-release-please-start-version
 runs:
   using: composite
   steps:
@@ -48,3 +49,4 @@ runs:
         repository-name: ${{ fromJson(inputs.check).repository-name }}
         repository-owner: ${{ fromJson(inputs.check).repository-owner }}
         if: ${{ fromJson(inputs.check).if }}
+# x-release-please-end-version


### PR DESCRIPTION
Changes in #58 introduced an issue where the YAML updater deleted comments (including licence headers), and removed package identifiers when updating version numbers 

https://github.com/GoogleCloudPlatform/cloud-samples-tools/commit/92b5b8dc6b40d1bcecfd887629d79ac71b2d8c74

This PR changes the yaml updater to a text updater, using start/end tags to scope the changes to just the `runs:` part of the workflow snippet. 

Using the [release-please troubleshooting docs](https://github.com/googleapis/release-please/blob/main/docs/troubleshooting.md#testing-in-another-branch), the output only says what file is changed, not the actual changes, so unfortuntely I need to rely on PR based iterations to ensure everything works as expected. 