### PR TITLE
chore: use explicit hash ref for actions/github-script

### DIFF
--- a/actions/steps/create-status/action.yaml
+++ b/actions/steps/create-status/action.yaml
@@ -47,7 +47,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
       id: check
       with:
         script: |

--- a/actions/steps/get-job/action.yaml
+++ b/actions/steps/get-job/action.yaml
@@ -40,7 +40,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
       id: job
       with:
         script: |


### PR DESCRIPTION
Add hashes so renovate-bot will also use hash references (safer) in update PRs, ex: #103 